### PR TITLE
WIP: VK_EXT_custom_border_color

### DIFF
--- a/appendices/VK_EXT_custom_border_color.txt
+++ b/appendices/VK_EXT_custom_border_color.txt
@@ -1,4 +1,4 @@
-include::{generated}/meta//VK_EXT_custom_border_color.txt[]
+include::{generated}/meta/VK_EXT_custom_border_color.txt[]
 
 *Last Modified Date*::
     2019-10-12

--- a/appendices/VK_EXT_custom_border_color.txt
+++ b/appendices/VK_EXT_custom_border_color.txt
@@ -18,10 +18,18 @@ When ename:VK_BORDER_COLOR_CUSTOM_EXT is supplied, applications must provide a
 slink:VkSamplerCustomBorderColorCreateInfoEXT in the pNext chain for
 slink:VkSamplerCreateInfo.
 
+For implementations with a limited number of border colors, they should be reference counted
+when the sampler is created/destroyed. This means that freeing the last sampler that used
+a custom border color will also free up the slot for another border color to be used.
+
+The implementation should maintain the guarantee that flink:vkCreateSampler and
+flink:vkDestroySampler is thread-safe when a custom border color is used.
+
 === New Enum Constants
 
   * Extending elink:VkStructureType:
   ** ename:VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT
+  ** ename:VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_PROPERTIES_EXT
 
   * Extending elink:VkBorderColor:
   ** ename:VK_BORDER_COLOR_CUSTOM_EXT
@@ -29,6 +37,7 @@ slink:VkSamplerCreateInfo.
 === New Structures
 
   * slink:VkSamplerCustomBorderColorCreateInfoEXT
+  * slink:VkPhysicalDeviceCustomBorderColorPropertiesEXT
 
 === New Functions
 
@@ -58,3 +67,8 @@ OPEN
   * Revision 2, 2019-10-11 (Liam Middlebrook)
     - Remove VkCustomBorderColor object and associated functions
     - Add issues concerning HW limitations for custom border color count
+
+  * Revision 3, 2019-10-12 (Joshua Ashton)
+    - Re-expose the limits for the maximum number of unique border colors
+    - Add extra details about border color tracking
+    - Fix typos

--- a/appendices/VK_EXT_custom_border_color.txt
+++ b/appendices/VK_EXT_custom_border_color.txt
@@ -1,7 +1,7 @@
 include::{generated}/meta//VK_EXT_custom_border_color.txt[]
 
 *Last Modified Date*::
-    2019-10-11
+    2019-10-12
 *IP Status*::
     No known IP claims.
 *Contributors*::
@@ -72,3 +72,6 @@ OPEN
     - Re-expose the limits for the maximum number of unique border colors
     - Add extra details about border color tracking
     - Fix typos
+
+  * Revision 4, 2019-10-12 (Joshua Ashton)
+    - Changed maxUniqueCustomBorderColors to a uint32_t from a VkDeviceSize

--- a/appendices/VK_EXT_custom_border_color.txt
+++ b/appendices/VK_EXT_custom_border_color.txt
@@ -1,7 +1,7 @@
 include::{generated}/meta/VK_EXT_custom_border_color.txt[]
 
 *Last Modified Date*::
-    2019-10-14
+    2019-10-15
 *IP Status*::
     No known IP claims.
 *Contributors*::

--- a/appendices/VK_EXT_custom_border_color.txt
+++ b/appendices/VK_EXT_custom_border_color.txt
@@ -12,9 +12,13 @@ This extension provides cross-vendor functionality to specify a custom border co
 for use when the sampler address mode ename:VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER is used.
 
 To create a sampler which uses a custom border color
-slink:VkSamplerCreateInfo::pname:borderColor must be set to ename:VK_BORDER_COLOR_CUSTOM_EXT.
+slink:VkSamplerCreateInfo::pname:borderColor must be set to one of:
+  * ename:VK_BORDER_COLOR_CUSTOM_FLOAT_EXT
+  * ename:VK_BORDER_COLOR_CUSTOM_INT_EXT
+  * ename:VK_BORDER_COLOR_CUSTOM_UINT_EXT
 
-When ename:VK_BORDER_COLOR_CUSTOM_EXT is supplied, applications must provide a
+When ename:VK_BORDER_COLOR_CUSTOM_FLOAT_EXT, ename:VK_BORDER_COLOR_CUSTOM_INT_EXT
+or ename:VK_BORDER_COLOR_CUSTOM_UINT_EXT is used, applications must provide a
 slink:VkSamplerCustomBorderColorCreateInfoEXT in the pNext chain for
 slink:VkSamplerCreateInfo.
 
@@ -33,7 +37,9 @@ flink:vkDestroySampler is thread-safe when a custom border color is used.
   ** ename:VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT
 
   * Extending elink:VkBorderColor:
-  ** ename:VK_BORDER_COLOR_CUSTOM_EXT
+  ** ename:VK_BORDER_COLOR_CUSTOM_FLOAT_EXT
+  ** ename:VK_BORDER_COLOR_CUSTOM_INT_EXT
+  ** ename:VK_BORDER_COLOR_CUSTOM_UINT_EXT
 
 === New Structures
 
@@ -47,9 +53,6 @@ flink:vkDestroySampler is thread-safe when a custom border color is used.
 
 1) Should VkClearColorValue be used for the border color value, or should we
 have our own struct/union?
-Do we need to specify the type of the input values for the components? This is
-more of a concern if VkClearColorValue is used here because it provides a union
-of float,int,uint types.
 
 OPEN
 
@@ -87,3 +90,7 @@ OPEN
 
   * Revision 5, 2019-10-14 (Liam Middlebrook)
     - Added features bit
+
+  * Revision 6, 2019-10-15 (Joshua Ashton)
+    - Type-ize VK_BORDER_COLOR_CUSTOM
+    - Fix const-ness on pNext of VkSamplerCustomBorderColorCreateInfoEXT

--- a/appendices/VK_EXT_custom_border_color.txt
+++ b/appendices/VK_EXT_custom_border_color.txt
@@ -1,7 +1,7 @@
 include::{generated}/meta/VK_EXT_custom_border_color.txt[]
 
 *Last Modified Date*::
-    2019-10-12
+    2019-10-14
 *IP Status*::
     No known IP claims.
 *Contributors*::
@@ -30,6 +30,7 @@ flink:vkDestroySampler is thread-safe when a custom border color is used.
   * Extending elink:VkStructureType:
   ** ename:VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT
   ** ename:VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_PROPERTIES_EXT
+  ** ename:VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT
 
   * Extending elink:VkBorderColor:
   ** ename:VK_BORDER_COLOR_CUSTOM_EXT
@@ -38,6 +39,7 @@ flink:vkDestroySampler is thread-safe when a custom border color is used.
 
   * slink:VkSamplerCustomBorderColorCreateInfoEXT
   * slink:VkPhysicalDeviceCustomBorderColorPropertiesEXT
+  * slink:VkPhysicalDeviceCustomBorderColorFeaturesEXT
 
 === New Functions
 
@@ -82,3 +84,6 @@ OPEN
 
   * Revision 4, 2019-10-12 (Joshua Ashton)
     - Changed maxUniqueCustomBorderColors to a uint32_t from a VkDeviceSize
+
+  * Revision 5, 2019-10-14 (Liam Middlebrook)
+    - Added features bit

--- a/appendices/VK_EXT_custom_border_color.txt
+++ b/appendices/VK_EXT_custom_border_color.txt
@@ -13,6 +13,7 @@ for use when the sampler address mode ename:VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BOR
 
 To create a sampler which uses a custom border color
 slink:VkSamplerCreateInfo::pname:borderColor must be set to one of:
+
   * ename:VK_BORDER_COLOR_CUSTOM_FLOAT_EXT
   * ename:VK_BORDER_COLOR_CUSTOM_INT_EXT
   * ename:VK_BORDER_COLOR_CUSTOM_UINT_EXT
@@ -22,12 +23,12 @@ or ename:VK_BORDER_COLOR_CUSTOM_UINT_EXT is used, applications must provide a
 slink:VkSamplerCustomBorderColorCreateInfoEXT in the pNext chain for
 slink:VkSamplerCreateInfo.
 
-For implementations with a limited number of border colors, they should be reference counted
-when the sampler is created/destroyed. This means that freeing the last sampler that used
-a custom border color will also free up the slot for another border color to be used.
+For implementations with a limited number of border colors, they must be reference counted:
 
-The implementation should maintain the guarantee that flink:vkCreateSampler and
-flink:vkDestroySampler is thread-safe when a custom border color is used.
+  * When a sampler is successfully created
+  * When a sampler is destroyed
+Guranteeing that freeing the last sampler that used a custom border color will also
+free up the slot for another border color to be used.
 
 === New Enum Constants
 

--- a/appendices/VK_EXT_custom_border_color.txt
+++ b/appendices/VK_EXT_custom_border_color.txt
@@ -27,7 +27,8 @@ For implementations with a limited number of border colors, they must be referen
 
   * When a sampler is successfully created
   * When a sampler is destroyed
-Guranteeing that freeing the last sampler that used a custom border color will also
+
+Guaranteeing that freeing the last sampler that used a custom border color will also
 free up the slot for another border color to be used.
 
 === New Enum Constants
@@ -68,7 +69,7 @@ OPEN
 3) Should this be supported for immutable samplers at all, or by a feature bit?
 Some implementations may not be able to support custom border colors on
 immutable samplers -- is it worthwhile enabling this to work on them for
-implementations that can support it, or forbbiding it entirely.
+implementations that can support it, or forbidding it entirely.
 
 OPEN
 

--- a/appendices/VK_EXT_custom_border_color.txt
+++ b/appendices/VK_EXT_custom_border_color.txt
@@ -6,7 +6,7 @@ include::{generated}/meta/VK_EXT_custom_border_color.txt[]
     No known IP claims.
 *Contributors*::
   - Joshua Ashton
-  - Liam Middlebrook, Nvidia
+  - Liam Middlebrook, NVIDIA
 
 This extension provides cross-vendor functionality to specify a custom border color
 for use when the sampler address mode ename:VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER is used.

--- a/appendices/VK_EXT_custom_border_color.txt
+++ b/appendices/VK_EXT_custom_border_color.txt
@@ -1,7 +1,7 @@
 include::{generated}/meta//VK_EXT_custom_border_color.txt[]
 
 *Last Modified Date*::
-    2019-10-10
+    2019-10-11
 *IP Status*::
     No known IP claims.
 *Contributors*::
@@ -9,55 +9,52 @@ include::{generated}/meta//VK_EXT_custom_border_color.txt[]
   - Liam Middlebrook, Nvidia
 
 This extension provides cross-vendor functionality to specify a custom border color
-for use when the texture address mode ename:VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER is used.
+for use when the sampler address mode ename:VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER is used.
 
-The implementation should guarantee that the creation/destruction functions are thread-safe
-if required.
+To create a sampler which uses a custom border color the `borderColor` attribute
+of slink:VkSamplerCreateInfo must be set to ename:VK_BORDER_COLOR_CUSTOM_EXT.
 
-The application should query slink:VkPhysicalDeviceCustomBorderColorFeaturesEXT if it desires to use border colors:
-slink:VkDeviceCustomBorderColorLimitsCreateInfoEXT should be specified at device-creation time as a pNext of VkDeviceCreateInfo
-if `hasLimits` is true in slink:VkPhysicalDeviceCustomBorderColorFeaturesEXT.
-Not specifying slink:VkDeviceCustomBorderColorLimitsCreateInfoEXT if `hasLimits` is true, will result in flink:vkCreateCustomBorderColorEXT returning VK_ERROR_TOO_MANY_OBJECTS.
-
-When creating a sampler with a custom border color, the `borderColor` attribute of 
-slink:VkSamplerCreateInfo should be set to ename:VK_BORDER_COLOR_CUSTOM, and
-have slink:VkSamplerCustomBorderColorCreateInfoEXT somewhere in the pNext chain.
-
-Using ename:VK_BORDER_COLOR_CUSTOM without a slink:VkSamplerCustomBorderColorCreateInfoEXT is undefined behaviour.
-slink:VkSamplerCustomBorderColorCreateInfoEXT will be ignored if ename:VK_BORDER_COLOR_CUSTOM is not specified for `borderColor`.
-
-=== New Object Types
-
-  * slink:VkCustomBorderColorEXT
+When ename:VK_BORDER_COLOR_CUSTOM_EXT is supplied, applications must provide a
+slink:VkSamplerCustomBorderColorCreateInfoEXT in the pNext chain for
+slink:VkSamplerCreateInfo.
 
 === New Enum Constants
 
   * Extending elink:VkStructureType:
-  ** ename:VK_STRUCTURE_TYPE_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT
   ** ename:VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT
-  ** ename:VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT
-  ** ename:VK_STRUCTURE_TYPE_DEVICE_CUSTOM_BORDER_COLOR_LIMITS_CREATE_INFO
 
   * Extending elink:VkBorderColor:
   ** ename:VK_BORDER_COLOR_CUSTOM_EXT
 
 === New Structures
 
-  * slink:VkCustomBorderColorCreateInfoEXT
   * slink:VkSamplerCustomBorderColorCreateInfoEXT
-  * slink:VkPhysicalDeviceCustomBorderColorFeaturesEXT
-  * slink:VkDeviceCustomBorderColorLimitsCreateInfoEXT
 
 === New Functions
 
-  * flink:vkCreateCustomBorderColorEXT
-  * flink:vkDestroyCustomBorderColorEXT
-
 === Issues
 
-1) Should VkClearColorValue be used for the border color value, or should we have our own struct/union?
+1) Should VkClearColorValue be used for the border color value, or should we
+have our own struct/union?
+Do we need to specify the type of the input values for the components? This is
+more of a concern if VkClearColorValue is used here because it provides a union
+of float,int,uint types.
+
+OPEN
+
+2) For hardware which supports a limited number of border colors what happens if
+that number is exceed? Should this be handled by the driver unbeknownst to the
+application. In Revision 1 we had solved this issue using a new Object type,
+however that may have lead to additional system resource consumption which would
+otherwise not be required.
+
+OPEN
 
 === Version History
 
   * Revision 1, 2019-10-10 (Joshua Ashton)
     - Internal revisions.
+
+  * Revision 2, 2019-10-11 (Liam Middlebrook)
+    - Remove VkCustomBorderColor object and associated functions
+    - Add issues concerning HW limitations for custom border color count

--- a/appendices/VK_EXT_custom_border_color.txt
+++ b/appendices/VK_EXT_custom_border_color.txt
@@ -1,7 +1,7 @@
 include::{generated}/meta/VK_EXT_custom_border_color.txt[]
 
 *Last Modified Date*::
-    2019-10-15
+    2019-11-26
 *IP Status*::
     No known IP claims.
 *Contributors*::
@@ -69,7 +69,7 @@ however that may have lead to additional system resource consumption which would
 otherwise not be required.
 
 RESOLVED: Added
-          sname:VkPhysicalDeviceCustomBorderColorPropertiesEXT::pname:maxUniqueCustomBorderColors
+          sname:VkPhysicalDeviceCustomBorderColorPropertiesEXT::pname:maxCustomBorderColors
           for tracking implementation-specific limit, and Valid Usage statement
           handling overflow.
 
@@ -103,3 +103,6 @@ OPEN
   * Revision 6, 2019-10-15 (Joshua Ashton)
     - Type-ize VK_BORDER_COLOR_CUSTOM
     - Fix const-ness on pNext of VkSamplerCustomBorderColorCreateInfoEXT
+
+  * Revision 7, 2019-11-26 (Liam Middlebrook)
+    - Renamed maxUniqueCustomBorderColors to maxCustomBorderColors

--- a/appendices/VK_EXT_custom_border_color.txt
+++ b/appendices/VK_EXT_custom_border_color.txt
@@ -11,8 +11,8 @@ include::{generated}/meta/VK_EXT_custom_border_color.txt[]
 This extension provides cross-vendor functionality to specify a custom border color
 for use when the sampler address mode ename:VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER is used.
 
-To create a sampler which uses a custom border color
-slink:VkSamplerCreateInfo::pname:borderColor must be set to one of:
+To create a sampler which uses a custom border color set
+slink:VkSamplerCreateInfo::pname:borderColor to one of:
 
   * ename:VK_BORDER_COLOR_CUSTOM_FLOAT_EXT
   * ename:VK_BORDER_COLOR_CUSTOM_INT_EXT

--- a/appendices/VK_EXT_custom_border_color.txt
+++ b/appendices/VK_EXT_custom_border_color.txt
@@ -70,8 +70,8 @@ otherwise not be required.
 
 RESOLVED: Added
           sname:VkPhysicalDeviceCustomBorderColorPropertiesEXT::pname:maxUniqueCustomBorderColors
-          for tracking implementation-specific limit. vkCreateSampler will fail
-          if limit exists and is exceeded.
+          for tracking implementation-specific limit, and Valid Usage statement
+          handling overflow.
 
 3) Should this be supported for immutable samplers at all, or by a feature bit?
 Some implementations may not be able to support custom border colors on

--- a/appendices/VK_EXT_custom_border_color.txt
+++ b/appendices/VK_EXT_custom_border_color.txt
@@ -11,8 +11,8 @@ include::{generated}/meta//VK_EXT_custom_border_color.txt[]
 This extension provides cross-vendor functionality to specify a custom border color
 for use when the sampler address mode ename:VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER is used.
 
-To create a sampler which uses a custom border color the `borderColor` attribute
-of slink:VkSamplerCreateInfo must be set to ename:VK_BORDER_COLOR_CUSTOM_EXT.
+To create a sampler which uses a custom border color
+slink:VkSamplerCreateInfo::pname:borderColor must be set to ename:VK_BORDER_COLOR_CUSTOM_EXT.
 
 When ename:VK_BORDER_COLOR_CUSTOM_EXT is supplied, applications must provide a
 slink:VkSamplerCustomBorderColorCreateInfoEXT in the pNext chain for

--- a/appendices/VK_EXT_custom_border_color.txt
+++ b/appendices/VK_EXT_custom_border_color.txt
@@ -68,7 +68,10 @@ application. In Revision 1 we had solved this issue using a new Object type,
 however that may have lead to additional system resource consumption which would
 otherwise not be required.
 
-OPEN
+RESOLVED: Added
+          sname:VkPhysicalDeviceCustomBorderColorPropertiesEXT::pname:maxUniqueCustomBorderColors
+          for tracking implementation-specific limit. vkCreateSampler will fail
+          if limit exists and is exceeded.
 
 3) Should this be supported for immutable samplers at all, or by a feature bit?
 Some implementations may not be able to support custom border colors on

--- a/appendices/VK_EXT_custom_border_color.txt
+++ b/appendices/VK_EXT_custom_border_color.txt
@@ -54,9 +54,13 @@ free up the slot for another border color to be used.
 === Issues
 
 1) Should VkClearColorValue be used for the border color value, or should we
-have our own struct/union?
+have our own struct/union? Do we need to specify the type of the input values
+for the components? This is more of a concern if VkClearColorValue is used here
+because it provides a union of float,int,uint types.
 
-OPEN
+RESOLVED: Will re-use existing VkClearColorValue structure in order to easily
+          take advantage of float,int,uint borderColor types.
+
 
 2) For hardware which supports a limited number of border colors what happens if
 that number is exceed? Should this be handled by the driver unbeknownst to the

--- a/appendices/VK_EXT_custom_border_color.txt
+++ b/appendices/VK_EXT_custom_border_color.txt
@@ -59,6 +59,13 @@ otherwise not be required.
 
 OPEN
 
+3) Should this be supported for immutable samplers at all, or by a feature bit?
+Some implementations may not be able to support custom border colors on
+immutable samplers -- is it worthwhile enabling this to work on them for
+implementations that can support it, or forbbiding it entirely.
+
+OPEN
+
 === Version History
 
   * Revision 1, 2019-10-10 (Joshua Ashton)

--- a/appendices/VK_EXT_custom_border_color.txt
+++ b/appendices/VK_EXT_custom_border_color.txt
@@ -1,0 +1,63 @@
+include::{generated}/meta//VK_EXT_custom_border_color.txt[]
+
+*Last Modified Date*::
+    2019-10-10
+*IP Status*::
+    No known IP claims.
+*Contributors*::
+  - Joshua Ashton
+  - Liam Middlebrook, Nvidia
+
+This extension provides cross-vendor functionality to specify a custom border color
+for use when the texture address mode ename:VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER is used.
+
+The implementation should guarantee that the creation/destruction functions are thread-safe
+if required.
+
+The application should query slink:VkPhysicalDeviceCustomBorderColorFeaturesEXT if it desires to use border colors:
+slink:VkDeviceCustomBorderColorLimitsCreateInfoEXT should be specified at device-creation time as a pNext of VkDeviceCreateInfo
+if `hasLimits` is true in slink:VkPhysicalDeviceCustomBorderColorFeaturesEXT.
+Not specifying slink:VkDeviceCustomBorderColorLimitsCreateInfoEXT if `hasLimits` is true, will result in flink:vkCreateCustomBorderColorEXT returning VK_ERROR_TOO_MANY_OBJECTS.
+
+When creating a sampler with a custom border color, the `borderColor` attribute of 
+slink:VkSamplerCreateInfo should be set to ename:VK_BORDER_COLOR_CUSTOM, and
+have slink:VkSamplerCustomBorderColorCreateInfoEXT somewhere in the pNext chain.
+
+Using ename:VK_BORDER_COLOR_CUSTOM without a slink:VkSamplerCustomBorderColorCreateInfoEXT is undefined behaviour.
+slink:VkSamplerCustomBorderColorCreateInfoEXT will be ignored if ename:VK_BORDER_COLOR_CUSTOM is not specified for `borderColor`.
+
+=== New Object Types
+
+  * slink:VkCustomBorderColorEXT
+
+=== New Enum Constants
+
+  * Extending elink:VkStructureType:
+  ** ename:VK_STRUCTURE_TYPE_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT
+  ** ename:VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT
+  ** ename:VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT
+  ** ename:VK_STRUCTURE_TYPE_DEVICE_CUSTOM_BORDER_COLOR_LIMITS_CREATE_INFO
+
+  * Extending elink:VkBorderColor:
+  ** ename:VK_BORDER_COLOR_CUSTOM_EXT
+
+=== New Structures
+
+  * slink:VkCustomBorderColorCreateInfoEXT
+  * slink:VkSamplerCustomBorderColorCreateInfoEXT
+  * slink:VkPhysicalDeviceCustomBorderColorFeaturesEXT
+  * slink:VkDeviceCustomBorderColorLimitsCreateInfoEXT
+
+=== New Functions
+
+  * flink:vkCreateCustomBorderColorEXT
+  * flink:vkDestroyCustomBorderColorEXT
+
+=== Issues
+
+1) Should VkClearColorValue be used for the border color value, or should we have our own struct/union?
+
+=== Version History
+
+  * Revision 1, 2019-10-10 (Joshua Ashton)
+    - Internal revisions.

--- a/chapters/features.txt
+++ b/chapters/features.txt
@@ -2637,7 +2637,9 @@ describe the following features:
 
   * [[features-customBorderColors]] pname:customBorderColors indicates
     that the implementation supports providing a custom borderColor value at
-    sampler creation time. XXX[ljm]{make this reference the createinfo struct}
+    sampler creation time. Applications are able to provide this custom value
+    through sname:VkSamplerCustomBorderColorCreateInfoEXT in the pname:pNext
+    chain of the sname:VkSamplerCreateInfo structure.
 
 include::{generated}/validity/structs/VkPhysicalDeviceCustomBorderColorFeaturesEXT.txt[]
 --

--- a/chapters/features.txt
+++ b/chapters/features.txt
@@ -2624,6 +2624,27 @@ include::{generated}/validity/structs/VkPhysicalDeviceCoherentMemoryFeaturesAMD.
 endif::VK_AMD_device_coherent_memory[]
 
 
+ifdef::VK_EXT_custom_border_color[]
+
+[open,refpage='VkPhysicalDeviceCustomBorderColorFeaturesEXT',desc='Structure describing whether custom border colors can be supported by an implementation',type='structs']
+--
+The sname:VkPhysicalDeviceCustomBorderColorFeaturesEXT structure is defined as:
+
+include::{generated}/api/structs/VkPhysicalDeviceCustomBorderColorFeaturesEXT.txt[]
+
+The members of the sname:VkPhysicalDeviceCustomBorderColorFeaturesEXT structure
+describe the following features:
+
+  * [[features-customBorderColors]] pname:customBorderColors indicates
+    that the implementation supports providing a custom borderColor value at
+    sampler creation time. XXX[ljm]{make this reference the createinfo struct}
+
+include::{generated}/validity/structs/VkPhysicalDeviceCustomBorderColorFeaturesEXT.txt[]
+--
+
+endif::VK_EXT_custom_border_color[]
+
+
 [[features-requirements]]
 == Feature Requirements
 

--- a/chapters/limits.txt
+++ b/chapters/limits.txt
@@ -3025,9 +3025,8 @@ The members of the sname:VkPhysicalDeviceCustomBorderColorPropertiesEXT structur
 describe the following features:
 
   * [[limits-maxUniqueCustomBorderColors]] pname:maxUniqueCustomBorderColors indicates
-    the maximum number of custom border colors the application may provide. If
-    pname:maxUniqueCustomBorderColors is zero, the implementation supports an
-    unlimited number of custom border colors.
+    the maximum number of custom border colors the application may use at the
+    same time.
 
 include::{generated}/validity/structs/VkPhysicalDeviceCustomBorderColorPropertiesEXT.txt[]
 --

--- a/chapters/limits.txt
+++ b/chapters/limits.txt
@@ -3025,7 +3025,9 @@ The members of the sname:VkPhysicalDeviceCustomBorderColorPropertiesEXT structur
 describe the following features:
 
   * [[limits-maxUniqueCustomBorderColors]] pname:maxUniqueCustomBorderColors indicates
-    the maximum number of custom border colors the application may provide.
+    the maximum number of custom border colors the application may provide. If
+    pname:maxUniqueCustomBorderColors is zero, the implementation supports an
+    unlimited number of custom border colors.
 
 include::{generated}/validity/structs/VkPhysicalDeviceCustomBorderColorPropertiesEXT.txt[]
 --

--- a/chapters/limits.txt
+++ b/chapters/limits.txt
@@ -2653,7 +2653,7 @@ ifdef::VK_EXT_line_rasterization[]
 | code:uint32_t            | pname:lineSubPixelPrecisionBits                | `<<VK_EXT_line_rasterization>>`
 endif::VK_EXT_line_rasterization[]
 ifdef::VK_EXT_custom_border_color[]
-| code:uint32_t            | pname:maxUniqueCustomBorderColors              | `<<VK_EXT_custom_border_color>>`
+| code:uint32_t            | pname:maxCustomBorderColors              | `<<VK_EXT_custom_border_color>>`
 endif::VK_EXT_custom_border_color[]
 |====
 
@@ -3024,7 +3024,7 @@ include::{generated}/api/structs/VkPhysicalDeviceCustomBorderColorPropertiesEXT.
 The members of the sname:VkPhysicalDeviceCustomBorderColorPropertiesEXT structure
 describe the following features:
 
-  * [[limits-maxUniqueCustomBorderColors]] pname:maxUniqueCustomBorderColors indicates
+  * [[limits-maxCustomBorderColors]] pname:maxCustomBorderColors indicates
     the maximum number of custom border colors the application may use at the
     same time.
 

--- a/chapters/limits.txt
+++ b/chapters/limits.txt
@@ -2652,6 +2652,9 @@ endif::VK_KHR_timeline_semaphore[]
 ifdef::VK_EXT_line_rasterization[]
 | code:uint32_t            | pname:lineSubPixelPrecisionBits                | `<<VK_EXT_line_rasterization>>`
 endif::VK_EXT_line_rasterization[]
+ifdef::VK_EXT_custom_border_color[]
+| code:uint32_t            | pname:maxUniqueCustomBorderColors              | `<<VK_EXT_custom_border_color>>`
+endif::VK_EXT_custom_border_color[]
 |====
 
 [[limits-required]]
@@ -3010,4 +3013,21 @@ respectively, otherwise both members must: be `0`.
 
 endif::VK_EXT_sample_locations[]
 
+ifdef::VK_EXT_custom_border_color[]
 
+[open,refpage='VkPhysicalDeviceCustomBorderColorPropertiesEXT',desc='Structure describing whether custom border colors can be supported by an implementation',type='structs']
+--
+The sname:VkPhysicalDeviceCustomBorderColorPropertiesEXT structure is defined as:
+
+include::{generated}/api/structs/VkPhysicalDeviceCustomBorderColorPropertiesEXT.txt[]
+
+The members of the sname:VkPhysicalDeviceCustomBorderColorPropertiesEXT structure
+describe the following features:
+
+  * [[limits-maxUniqueCustomBorderColors]] pname:maxUniqueCustomBorderColors indicates
+    the maximum number of custom border colors the application may provide.
+
+include::{generated}/validity/structs/VkPhysicalDeviceCustomBorderColorPropertiesEXT.txt[]
+--
+
+endif::VK_EXT_custom_border_color[]

--- a/chapters/samplers.txt
+++ b/chapters/samplers.txt
@@ -905,7 +905,7 @@ include::{generated}/api/structs/VkSamplerCustomBorderColorCreateInfoEXT.txt[]
   * [[VUID-VkSamplerCustomBorderColorCreateInfo-maxUnique-00000]]
   The maximum number of custom border colors which can: be simultaneously
   created on a device is implementation-dependent and specified by the
-  <<limits-maxUniqueCustomBorderColors,maxUniqueCustomBorderColors>> member of
+  <<limits-maxCustomBorderColors,maxCustomBorderColors>> member of
   the slink:VkPhysicalDeviceCustomBorderColorPropertiesEXT structure.
 ****
 

--- a/chapters/samplers.txt
+++ b/chapters/samplers.txt
@@ -897,8 +897,8 @@ include::{generated}/api/structs/VkSamplerCustomBorderColorCreateInfoEXT.txt[]
 
   * pname:sType is the type of this structure.
   * pname:pNext is `NULL` or a pointer to an extension-specific structure.
-  * pname:borderColor is a slink:VkClearColorValue representing the sampler
-    color. XXX[ljm]{fix this wording, right now is a bit circular}
+  * pname:borderColor is a slink:VkClearColorValue representing the desired
+    custom sampler color.
 
 .Valid Usage
 ****

--- a/chapters/samplers.txt
+++ b/chapters/samplers.txt
@@ -435,6 +435,13 @@ include::{generated}/api/enums/VkBorderColor.txt[]
 These colors are described in detail in <<textures-texel-replacement, Texel
 Replacement>>.
 
+ifdef::VK_EXT_custom_border_color[]
+  * ename:VK_BORDER_COLOR_CUSTOM_EXT indicates that a
+    slink:VkSamplerCustomBorderColorCreateInfoEXT structure is present in the
+    slink::VkSamplerCreateInfo::pname:pNext chain which contains color date
+    representative of a color which may not be listed above.
+endif::VK_EXT_custom_border_color[]
+
 --
 
 [open,refpage='vkDestroySampler',desc='Destroy a sampler object',type='protos']
@@ -856,3 +863,26 @@ include::{generated}/validity/protos/vkDestroySamplerYcbcrConversion.txt[]
 --
 
 endif::VK_VERSION_1_1,VK_KHR_sampler_ycbcr_conversion[]
+
+ifdef::VK_EXT_custom_border_color[]
+
+[open,refpage='VkSamplerCustomBorderColorCreateInfoEXT',desc='Structure specifying custom border color',type='structs']
+--
+
+Applications may wish to provide a custom border color which is not listed under
+ename:VkBorderColor, this structure allows for specifying a custom color value
+to be added to the slink:VkSamplerCreateInfo::pname:pNext chain.
+
+The sname:VkSamplerCustomBorderColorCreateInfoEXT structure is defined as:
+
+include::{generated}/api/structs/VkSamplerCustomBorderColorCreateInfoEXT.txt[]
+
+  * pname:sType is the type of this structure.
+  * pname:pNext is `NULL` or a pointer to an extension-specific structure.
+  * pname:borderColor is a elink:VkClearColor value representing the sampler
+    color. XXX[ljm]{fix this wording, right now is a bit circular}
+
+include::{generated}/validity/structs/VkSamplerCustomBorderColorCreateInfoEXT.txt[]
+--
+
+endif::VK_EXT_custom_border_color[]

--- a/chapters/samplers.txt
+++ b/chapters/samplers.txt
@@ -904,7 +904,7 @@ include::{generated}/api/structs/VkSamplerCustomBorderColorCreateInfoEXT.txt[]
 ****
   * [[VUID-VkSamplerCustomBorderColorCreateInfo-maxUnique]]
   The maximum number of custom border colors which can: be simultaneously
-  created on a device is implementation-dependent and specfied by the
+  created on a device is implementation-dependent and specified by the
   <<limits-maxUniqueCustomBorderColors,maxUniqueCustomBorderColors>> member of
   the slink:VkPhysicalDeviceCustomBorderColorPropertiesEXT structure. If
   pname:maxUniqueCustomBorderColors is zero, the implementation supports an

--- a/chapters/samplers.txt
+++ b/chapters/samplers.txt
@@ -879,7 +879,7 @@ include::{generated}/api/structs/VkSamplerCustomBorderColorCreateInfoEXT.txt[]
 
   * pname:sType is the type of this structure.
   * pname:pNext is `NULL` or a pointer to an extension-specific structure.
-  * pname:borderColor is a elink:VkClearColor value representing the sampler
+  * pname:borderColor is a slink:VkClearColorValue representing the sampler
     color. XXX[ljm]{fix this wording, right now is a bit circular}
 
 include::{generated}/validity/structs/VkSamplerCustomBorderColorCreateInfoEXT.txt[]

--- a/chapters/samplers.txt
+++ b/chapters/samplers.txt
@@ -438,7 +438,7 @@ Replacement>>.
 ifdef::VK_EXT_custom_border_color[]
   * ename:VK_BORDER_COLOR_CUSTOM_EXT indicates that a
     slink:VkSamplerCustomBorderColorCreateInfoEXT structure is present in the
-    slink::VkSamplerCreateInfo::pname:pNext chain which contains color date
+    slink::VkSamplerCreateInfo::pname:pNext chain which contains color data
     representative of a color which may not be listed above.
 endif::VK_EXT_custom_border_color[]
 

--- a/chapters/samplers.txt
+++ b/chapters/samplers.txt
@@ -903,7 +903,14 @@ include::{generated}/api/structs/VkSamplerCustomBorderColorCreateInfoEXT.txt[]
 .Valid Usage
 ****
   * [[VUID-VkSamplerCustomBorderColorCreateInfo-maxUnique]]
-  The application must not exceed the number of sname:VkPhysicalDeviceCustomBorderColorPropertiesEXT::pname:maxUniqueCustomBorderColors if it is non-zero.
+  The maximum number of custom border colors which can: be simultaneously
+  created on a device is implementation-dependent and specfied by the
+  <<limits-maxUniqueCustomBorderColors,maxUniqueCustomBorderColors>> member of
+  the slink:VkPhysicalDeviceCustomBorderColorPropertiesEXT structure. If
+  pname:maxUniqueCustomBorderColors is zero, the implementation supports an
+  unlimited number of custom border colors.
+  If pname:maxUniqueCustomBorderColors is exceeded, fname:vkCreateSampler will
+  return ename:VK_ERROR_TOO_MANY_OBJECTS
 ****
 
 include::{generated}/validity/structs/VkSamplerCustomBorderColorCreateInfoEXT.txt[]

--- a/chapters/samplers.txt
+++ b/chapters/samplers.txt
@@ -261,6 +261,17 @@ ifdef::VK_EXT_fragment_density_map[]
     If pname:flags includes ename:VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, then
     pname:unnormalizedCoordinates must: be ename:VK_FALSE.
 endif::VK_EXT_fragment_density_map[]
+ifdef::VK_EXT_custom_border_color[]
+  * [[VUID-something-something-something]]
+    If pname:borderColor is set to one of:
++
+    ** ename:VK_BORDER_COLOR_CUSTOM_FLOAT_EXT
+    ** ename:VK_BORDER_COLOR_CUSTOM_INT_EXT
+    ** ename:VK_BORDER_COLOR_CUSTOM_UINT_EXT
++
+then a slink:VkSamplerCustomBorderColorCreateInfoEXT must: be present
+in the pname:pNext chain.
+endif::VK_EXT_custom_border_color[]
 ****
 
 include::{generated}/validity/structs/VkSamplerCreateInfo.txt[]
@@ -431,16 +442,23 @@ include::{generated}/api/enums/VkBorderColor.txt[]
     floating-point format, white color.
   * ename:VK_BORDER_COLOR_INT_OPAQUE_WHITE specifies an opaque, integer
     format, white color.
+ifdef::VK_EXT_custom_border_color[]
+  * ename:VK_BORDER_COLOR_CUSTOM_FLOAT_EXT indicates that a
+    slink:VkSamplerCustomBorderColorCreateInfoEXT structure is present in the
+    slink:VkSamplerCreateInfo::pname:pNext chain which contains color data
+    representative of a color which may not be listed above, floating-point format.
+  * ename:VK_BORDER_COLOR_CUSTOM_INT_EXT indicates that a
+    slink:VkSamplerCustomBorderColorCreateInfoEXT structure is present in the
+    slink:VkSamplerCreateInfo::pname:pNext chain which contains color data
+    representative of a color which may not be listed above, integer format.
+  * ename:VK_BORDER_COLOR_CUSTOM_UINT_EXT indicates that a
+    slink:VkSamplerCustomBorderColorCreateInfoEXT structure is present in the
+    slink:VkSamplerCreateInfo::pname:pNext chain which contains color data
+    representative of a color which may not be listed above, unsigned integer format.
+endif::VK_EXT_custom_border_color[]
 
 These colors are described in detail in <<textures-texel-replacement, Texel
 Replacement>>.
-
-ifdef::VK_EXT_custom_border_color[]
-  * ename:VK_BORDER_COLOR_CUSTOM_EXT indicates that a
-    slink:VkSamplerCustomBorderColorCreateInfoEXT structure is present in the
-    slink::VkSamplerCreateInfo::pname:pNext chain which contains color data
-    representative of a color which may not be listed above.
-endif::VK_EXT_custom_border_color[]
 
 --
 
@@ -869,7 +887,7 @@ ifdef::VK_EXT_custom_border_color[]
 [open,refpage='VkSamplerCustomBorderColorCreateInfoEXT',desc='Structure specifying custom border color',type='structs']
 --
 
-Applications may wish to provide a custom border color which is not listed under
+Applications can provide a custom border color which is not listed under
 ename:VkBorderColor, this structure allows for specifying a custom color value
 to be added to the slink:VkSamplerCreateInfo::pname:pNext chain.
 
@@ -882,7 +900,14 @@ include::{generated}/api/structs/VkSamplerCustomBorderColorCreateInfoEXT.txt[]
   * pname:borderColor is a slink:VkClearColorValue representing the sampler
     color. XXX[ljm]{fix this wording, right now is a bit circular}
 
+.Valid Usage
+****
+  * [[VUID-something-something-something]]
+  The application must not exceed the number of sname:VkPhysicalDeviceCustomBorderColorPropertiesEXT::pname:maxUniqueCustomBorderColors if it is non-zero.
+****
+
 include::{generated}/validity/structs/VkSamplerCustomBorderColorCreateInfoEXT.txt[]
+
 --
 
 endif::VK_EXT_custom_border_color[]

--- a/chapters/samplers.txt
+++ b/chapters/samplers.txt
@@ -887,7 +887,7 @@ ifdef::VK_EXT_custom_border_color[]
 [open,refpage='VkSamplerCustomBorderColorCreateInfoEXT',desc='Structure specifying custom border color',type='structs']
 --
 
-Applications can provide a custom border color which is not listed under
+Applications can: provide a custom border color which is not listed under
 ename:VkBorderColor, this structure allows for specifying a custom color value
 to be added to the slink:VkSamplerCreateInfo::pname:pNext chain.
 

--- a/chapters/samplers.txt
+++ b/chapters/samplers.txt
@@ -262,7 +262,7 @@ ifdef::VK_EXT_fragment_density_map[]
     pname:unnormalizedCoordinates must: be ename:VK_FALSE.
 endif::VK_EXT_fragment_density_map[]
 ifdef::VK_EXT_custom_border_color[]
-  * [[VUID-something-something-something]]
+  * [[VUID-VkSamplerCreateInfo-flags-02581]]
     If pname:borderColor is set to one of:
 +
     ** ename:VK_BORDER_COLOR_CUSTOM_FLOAT_EXT
@@ -902,7 +902,7 @@ include::{generated}/api/structs/VkSamplerCustomBorderColorCreateInfoEXT.txt[]
 
 .Valid Usage
 ****
-  * [[VUID-something-something-something]]
+  * [[VUID-VkSamplerCustomBorderColorCreateInfo-maxUnique]]
   The application must not exceed the number of sname:VkPhysicalDeviceCustomBorderColorPropertiesEXT::pname:maxUniqueCustomBorderColors if it is non-zero.
 ****
 

--- a/chapters/samplers.txt
+++ b/chapters/samplers.txt
@@ -902,15 +902,11 @@ include::{generated}/api/structs/VkSamplerCustomBorderColorCreateInfoEXT.txt[]
 
 .Valid Usage
 ****
-  * [[VUID-VkSamplerCustomBorderColorCreateInfo-maxUnique]]
+  * [[VUID-VkSamplerCustomBorderColorCreateInfo-maxUnique-00000]]
   The maximum number of custom border colors which can: be simultaneously
   created on a device is implementation-dependent and specified by the
   <<limits-maxUniqueCustomBorderColors,maxUniqueCustomBorderColors>> member of
-  the slink:VkPhysicalDeviceCustomBorderColorPropertiesEXT structure. If
-  pname:maxUniqueCustomBorderColors is zero, the implementation supports an
-  unlimited number of custom border colors.
-  If pname:maxUniqueCustomBorderColors is exceeded, fname:vkCreateSampler will
-  return ename:VK_ERROR_TOO_MANY_OBJECTS
+  the slink:VkPhysicalDeviceCustomBorderColorPropertiesEXT structure.
 ****
 
 include::{generated}/validity/structs/VkSamplerCustomBorderColorCreateInfoEXT.txt[]

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -11603,7 +11603,7 @@ typedef void <name>CAMetalLayer</name>;
                 <enum value="1"                                             name="VK_EXT_CUSTOM_BORDER_COLOR_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_custom_border_color&quot;"        name="VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT"/>
-                <enum offset="0" extends="VkBorderColor"                    name="VK_BORDER_COLOR_CUSTOM_EXT"/>
+                <enum offset="1" extends="VkBorderColor"                    name="VK_BORDER_COLOR_CUSTOM_EXT"/>
                 <type name="VkSamplerCustomBorderColorCreateInfoEXT"/>
             </require>
         </extension>

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -4208,7 +4208,12 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkSamplerCustomBorderColorCreateInfoEXT" structextends="VkSamplerCreateInfo">
             <member values="VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member noautovalidity="true"><type>void</type>*                                                            <name>pNext</name></member>
-            <member><type>VkClearColorValue</type>                                                                 <name>borderColor</name></member>
+            <member><type>VkClearColorValue</type>                                                                      <name>borderColor</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceCustomBorderColorPropertiesEXT" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true"><type>void</type>*                                                                   <name>pNext</name></member>
+            <member><type>VkDeviceSize</type>                                                                                  <name>maxUniqueCustomBorderColors</name></member>
         </type>
     </types>
 
@@ -11603,8 +11608,10 @@ typedef void <name>CAMetalLayer</name>;
                 <enum value="1"                                             name="VK_EXT_CUSTOM_BORDER_COLOR_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_custom_border_color&quot;"        name="VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT"/>
-                <enum offset="1" extends="VkBorderColor"                    name="VK_BORDER_COLOR_CUSTOM_EXT"/>
+                <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_PROPERTIES_EXT"/>
+                <enum offset="2" extends="VkBorderColor"                    name="VK_BORDER_COLOR_CUSTOM_EXT"/>
                 <type name="VkSamplerCustomBorderColorCreateInfoEXT"/>
+                <type name="VkPhysicalDeviceCustomBorderColorPropertiesEXT"/>
             </require>
         </extension>
         <extension name="VK_EXT_extension_289" number="289" author="EXT" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="disabled">

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -4213,7 +4213,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceCustomBorderColorPropertiesEXT" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member noautovalidity="true"><type>void</type>*                                                                   <name>pNext</name></member>
-            <member><type>VkDeviceSize</type>                                                                                  <name>maxUniqueCustomBorderColors</name></member>
+            <member><type>uint32_t</type>                                                                                      <name>maxUniqueCustomBorderColors</name></member>
         </type>
     </types>
 

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -374,6 +374,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="handle" parent="VkDevice"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkValidationCacheEXT</name>)</type>
         <type category="handle" parent="VkDevice"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkAccelerationStructureNV</name>)</type>
         <type category="handle" parent="VkDevice"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkPerformanceConfigurationINTEL</name>)</type>
+        <type category="handle" parent="VkDevice"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkCustomBorderColorEXT</name>)</type>
 
             <comment>WSI extensions</comment>
         <type category="handle"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkDisplayKHR</name>)</type>
@@ -4205,6 +4206,26 @@ typedef void <name>CAMetalLayer</name>;
             <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>deviceCoherentMemory</name></member>
         </type>
+        <type category="struct" name="VkCustomBorderColorCreateInfoEXT">
+            <member values="VK_STRUCTURE_TYPE_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true"><type>void</type>*                                                    <name>pNext</name></member>
+            <member><type>VkClearColorValue</type>                                                              <name>value</name></member>
+        </type>
+        <type category="struct" name="VkSamplerCustomBorderColorCreateInfoEXT" structextends="VkSamplerCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true"><type>void</type>*                                                            <name>pNext</name></member>
+            <member><type>VkCustomBorderColorEXT</type>                                                                 <name>borderColor</name></member>
+        </type>
+        <type category="struct" name="VkPhysicalDeviceCustomBorderColorFeaturesEXT" structextends="VkPhysicalDeviceFeatures2" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true"><type>void</type>*                                                                 <name>pNext</name></member>
+            <member><type>VkBool32</type>                                                                                    <name>hasLimits</name></member>
+        </type>
+        <type category="struct" name="VkDeviceCustomBorderColorLimitsCreateInfoEXT" structextends="VkDeviceCreateInfo" returnedonly="true">
+            <member values="VK_STRUCTURE_TYPE_DEVICE_CUSTOM_BORDER_COLOR_LIMITS_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true"><type>void</type>*                                                                  <name>pNext</name></member>
+            <member><type>VkDeviceSize</type>                                                                                 <name>borderColorCount</name></member>
+        </type>
     </types>
 
     <comment>Vulkan enumerant (token) definitions</comment>
@@ -7846,6 +7867,19 @@ typedef void <name>CAMetalLayer</name>;
             <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
             <param><type>uint32_t</type> <name>lineStippleFactor</name></param>
             <param><type>uint16_t</type> <name>lineStipplePattern</name></param>
+        </command>
+        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY">
+            <proto><type>VkResult</type> <name>vkCreateCustomBorderColorEXT</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param>const <type>VkCustomBorderColorCreateInfoEXT</type>* <name>pCreateInfo</name></param>
+            <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
+            <param><type>VkCustomBorderColorEXT</type>* <name>pBorderColor</name></param>
+        </command>
+        <command>
+            <proto><type>void</type> <name>vkDestroyCustomBorderColorEXT</name></proto>
+            <param><type>VkDevice</type> <name>device</name></param>
+            <param><type>VkCustomBorderColorEXT</type> <name>borderColor</name></param>
+            <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
         </command>
     </commands>
 
@@ -11593,10 +11627,23 @@ typedef void <name>CAMetalLayer</name>;
                 <enum value="&quot;VK_NVX_extension_287&quot;"              name="VK_NVX_EXTENSION_287_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_NVX_extension_288" number="288" author="NVX" contact="Liam Middlebrook @liam-middlebrook" supported="disabled">
+        <extension name="VK_EXT_custom_border_color" number="288" type="device" author="EXT" contact="Liam Middlebrook @liam-middlebrook" supported="vulkan">
             <require>
-                <enum value="0"                                             name="VK_NVX_EXTENSION_288_SPEC_VERSION"/>
-                <enum value="&quot;VK_NVX_extension_288&quot;"              name="VK_NVX_EXTENSION_288_EXTENSION_NAME"/>
+                <enum value="1"                                             name="VK_EXT_CUSTOM_BORDER_COLOR_SPEC_VERSION"/>
+                <enum value="&quot;VK_EXT_custom_border_color&quot;"        name="VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT"/>
+                <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT"/>
+                <enum offset="2" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT"/>
+                <enum offset="3" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_DEVICE_CUSTOM_BORDER_COLOR_LIMITS_CREATE_INFO_EXT"/>
+                <enum offset="0" extends="VkObjectType"                     name="VK_OBJECT_TYPE_CUSTOM_BORDER_COLOR_EXT" comment="VkCustomBorderColorEXT"/>
+                <enum offset="0" extends="VkBorderColor"                    name="VK_BORDER_COLOR_CUSTOM_EXT"/>
+                <type name="VkCustomBorderColorCreateInfoEXT"/>
+                <type name="VkSamplerCustomBorderColorCreateInfoEXT"/>
+                <type name="VkPhysicalDeviceCustomBorderColorFeaturesEXT"/>
+                <type name="VkDeviceCustomBorderColorLimitsCreateInfoEXT"/>
+                <type name="VkCustomBorderColorEXT"/>
+                <command name="vkCreateCustomBorderColorEXT"/>
+                <command name="vkDestroyCustomBorderColorEXT"/>
             </require>
         </extension>
         <extension name="VK_EXT_extension_289" number="289" author="EXT" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="disabled">

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -4213,7 +4213,7 @@ typedef void <name>CAMetalLayer</name>;
         <type category="struct" name="VkPhysicalDeviceCustomBorderColorPropertiesEXT" structextends="VkPhysicalDeviceProperties2" returnedonly="true">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_PROPERTIES_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member noautovalidity="true"><type>void</type>*                                                                   <name>pNext</name></member>
-            <member><type>uint32_t</type>                                                                                      <name>maxUniqueCustomBorderColors</name></member>
+            <member><type>uint32_t</type>                                                                                      <name>maxCustomBorderColors</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceCustomBorderColorFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
             <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -4207,7 +4207,7 @@ typedef void <name>CAMetalLayer</name>;
         </type>
         <type category="struct" name="VkSamplerCustomBorderColorCreateInfoEXT" structextends="VkSamplerCreateInfo">
             <member values="VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*                                                            <name>pNext</name></member>
+            <member>const <type>void</type>*                                                                            <name>pNext</name></member>
             <member><type>VkClearColorValue</type>                                                                      <name>borderColor</name></member>
         </type>
         <type category="struct" name="VkPhysicalDeviceCustomBorderColorPropertiesEXT" structextends="VkPhysicalDeviceProperties2" returnedonly="true">

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -11615,7 +11615,9 @@ typedef void <name>CAMetalLayer</name>;
                 <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT"/>
                 <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_PROPERTIES_EXT"/>
                 <enum offset="2" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT"/>
-                <enum offset="3" extends="VkBorderColor"                    name="VK_BORDER_COLOR_CUSTOM_EXT"/>
+                <enum offset="3" extends="VkBorderColor"                    name="VK_BORDER_COLOR_CUSTOM_FLOAT_EXT"/>
+                <enum offset="4" extends="VkBorderColor"                    name="VK_BORDER_COLOR_CUSTOM_INT_EXT"/>
+                <enum offset="5" extends="VkBorderColor"                    name="VK_BORDER_COLOR_CUSTOM_UINT_EXT"/>
                 <type name="VkSamplerCustomBorderColorCreateInfoEXT"/>
                 <type name="VkPhysicalDeviceCustomBorderColorPropertiesEXT"/>
                 <type name="VkPhysicalDeviceCustomBorderColorFeaturesEXT"/>

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -4215,6 +4215,11 @@ typedef void <name>CAMetalLayer</name>;
             <member noautovalidity="true"><type>void</type>*                                                                   <name>pNext</name></member>
             <member><type>uint32_t</type>                                                                                      <name>maxUniqueCustomBorderColors</name></member>
         </type>
+        <type category="struct" name="VkPhysicalDeviceCustomBorderColorFeaturesEXT" structextends="VkPhysicalDeviceFeatures2,VkDeviceCreateInfo">
+            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
+            <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
+            <member><type>VkBool32</type>                           <name>customBorderColors</name></member>
+        </type>
     </types>
 
     <comment>Vulkan enumerant (token) definitions</comment>
@@ -11609,9 +11614,11 @@ typedef void <name>CAMetalLayer</name>;
                 <enum value="&quot;VK_EXT_custom_border_color&quot;"        name="VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME"/>
                 <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT"/>
                 <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_PROPERTIES_EXT"/>
-                <enum offset="2" extends="VkBorderColor"                    name="VK_BORDER_COLOR_CUSTOM_EXT"/>
+                <enum offset="2" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT"/>
+                <enum offset="3" extends="VkBorderColor"                    name="VK_BORDER_COLOR_CUSTOM_EXT"/>
                 <type name="VkSamplerCustomBorderColorCreateInfoEXT"/>
                 <type name="VkPhysicalDeviceCustomBorderColorPropertiesEXT"/>
+                <type name="VkPhysicalDeviceCustomBorderColorFeaturesEXT"/>
             </require>
         </extension>
         <extension name="VK_EXT_extension_289" number="289" author="EXT" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="disabled">

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -374,7 +374,6 @@ typedef void <name>CAMetalLayer</name>;
         <type category="handle" parent="VkDevice"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkValidationCacheEXT</name>)</type>
         <type category="handle" parent="VkDevice"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkAccelerationStructureNV</name>)</type>
         <type category="handle" parent="VkDevice"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkPerformanceConfigurationINTEL</name>)</type>
-        <type category="handle" parent="VkDevice"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkCustomBorderColorEXT</name>)</type>
 
             <comment>WSI extensions</comment>
         <type category="handle"><type>VK_DEFINE_NON_DISPATCHABLE_HANDLE</type>(<name>VkDisplayKHR</name>)</type>
@@ -4206,25 +4205,10 @@ typedef void <name>CAMetalLayer</name>;
             <member noautovalidity="true"><type>void</type>*        <name>pNext</name></member>
             <member><type>VkBool32</type>                           <name>deviceCoherentMemory</name></member>
         </type>
-        <type category="struct" name="VkCustomBorderColorCreateInfoEXT">
-            <member values="VK_STRUCTURE_TYPE_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*                                                    <name>pNext</name></member>
-            <member><type>VkClearColorValue</type>                                                              <name>value</name></member>
-        </type>
         <type category="struct" name="VkSamplerCustomBorderColorCreateInfoEXT" structextends="VkSamplerCreateInfo">
             <member values="VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
             <member noautovalidity="true"><type>void</type>*                                                            <name>pNext</name></member>
-            <member><type>VkCustomBorderColorEXT</type>                                                                 <name>borderColor</name></member>
-        </type>
-        <type category="struct" name="VkPhysicalDeviceCustomBorderColorFeaturesEXT" structextends="VkPhysicalDeviceFeatures2" returnedonly="true">
-            <member values="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*                                                                 <name>pNext</name></member>
-            <member><type>VkBool32</type>                                                                                    <name>hasLimits</name></member>
-        </type>
-        <type category="struct" name="VkDeviceCustomBorderColorLimitsCreateInfoEXT" structextends="VkDeviceCreateInfo" returnedonly="true">
-            <member values="VK_STRUCTURE_TYPE_DEVICE_CUSTOM_BORDER_COLOR_LIMITS_CREATE_INFO_EXT"><type>VkStructureType</type> <name>sType</name></member>
-            <member noautovalidity="true"><type>void</type>*                                                                  <name>pNext</name></member>
-            <member><type>VkDeviceSize</type>                                                                                 <name>borderColorCount</name></member>
+            <member><type>VkClearColorValue</type>                                                                 <name>borderColor</name></member>
         </type>
     </types>
 
@@ -7867,19 +7851,6 @@ typedef void <name>CAMetalLayer</name>;
             <param externsync="true"><type>VkCommandBuffer</type> <name>commandBuffer</name></param>
             <param><type>uint32_t</type> <name>lineStippleFactor</name></param>
             <param><type>uint16_t</type> <name>lineStipplePattern</name></param>
-        </command>
-        <command successcodes="VK_SUCCESS" errorcodes="VK_ERROR_TOO_MANY_OBJECTS,VK_ERROR_OUT_OF_HOST_MEMORY">
-            <proto><type>VkResult</type> <name>vkCreateCustomBorderColorEXT</name></proto>
-            <param><type>VkDevice</type> <name>device</name></param>
-            <param>const <type>VkCustomBorderColorCreateInfoEXT</type>* <name>pCreateInfo</name></param>
-            <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
-            <param><type>VkCustomBorderColorEXT</type>* <name>pBorderColor</name></param>
-        </command>
-        <command>
-            <proto><type>void</type> <name>vkDestroyCustomBorderColorEXT</name></proto>
-            <param><type>VkDevice</type> <name>device</name></param>
-            <param><type>VkCustomBorderColorEXT</type> <name>borderColor</name></param>
-            <param optional="true">const <type>VkAllocationCallbacks</type>* <name>pAllocator</name></param>
         </command>
     </commands>
 
@@ -11631,19 +11602,9 @@ typedef void <name>CAMetalLayer</name>;
             <require>
                 <enum value="1"                                             name="VK_EXT_CUSTOM_BORDER_COLOR_SPEC_VERSION"/>
                 <enum value="&quot;VK_EXT_custom_border_color&quot;"        name="VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME"/>
-                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT"/>
-                <enum offset="1" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT"/>
-                <enum offset="2" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT"/>
-                <enum offset="3" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_DEVICE_CUSTOM_BORDER_COLOR_LIMITS_CREATE_INFO_EXT"/>
-                <enum offset="0" extends="VkObjectType"                     name="VK_OBJECT_TYPE_CUSTOM_BORDER_COLOR_EXT" comment="VkCustomBorderColorEXT"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT"/>
                 <enum offset="0" extends="VkBorderColor"                    name="VK_BORDER_COLOR_CUSTOM_EXT"/>
-                <type name="VkCustomBorderColorCreateInfoEXT"/>
                 <type name="VkSamplerCustomBorderColorCreateInfoEXT"/>
-                <type name="VkPhysicalDeviceCustomBorderColorFeaturesEXT"/>
-                <type name="VkDeviceCustomBorderColorLimitsCreateInfoEXT"/>
-                <type name="VkCustomBorderColorEXT"/>
-                <command name="vkCreateCustomBorderColorEXT"/>
-                <command name="vkDestroyCustomBorderColorEXT"/>
             </require>
         </extension>
         <extension name="VK_EXT_extension_289" number="289" author="EXT" contact="Jan-Harald Fredriksen @janharaldfredriksen-arm" supported="disabled">


### PR DESCRIPTION
This extension provides cross-vendor functionality to specify a custom border color for use when the sampler address mode VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER is used.