### PR TITLE
Initial work on VK_VALVE_partial_presentation

### DIFF
--- a/appendices/VK_VALVE_partial_presentation.txt
+++ b/appendices/VK_VALVE_partial_presentation.txt
@@ -1,0 +1,34 @@
+// Copyright (c) 2019-2020 The Khronos Group Inc.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+include::{generated}/meta/{refprefix}VK_VALVE_partial_present.txt[]
+
+=== Other Extension Metadata
+
+*Last Modified Date*::
+    2020-06-23
+*IP Status*::
+    No known IP claims.
+*Contributors*::
+  - Joshua Ashton, Valve
+
+=== Description
+
+This device extension extends flink:vkQueuePresentKHR, from the
+`<<VK_KHR_swapchain>>` extension, and the functionality
+provided by `<<VK_KHR_incremental_present>>` to also allow a new
+set of exclusive regions for each image that will be updated as well
+as an offset into the source swapchain image(s).
+
+include::{generated}/interfaces/VK_VALVE_partial_present.txt[]
+
+=== Issues
+
+1) Should we call the dirty/changed regions pDamageRegions, pDirtyRegions
+or something else?
+
+=== Version History
+
+  * Revision 1, 2020-06-23 (Joshua Ashton)
+    - Internal revisions.

--- a/chapters/VK_KHR_swapchain/wsi.txt
+++ b/chapters/VK_KHR_swapchain/wsi.txt
@@ -1318,6 +1318,10 @@ ifdef::VK_KHR_incremental_present[]
 include::{chapters}/VK_KHR_incremental_present/wsi.txt[]
 endif::VK_KHR_incremental_present[]
 
+ifdef::VK_VALVE_partial_present[]
+include::{chapters}/VK_VALVE_partial_present/wsi.txt[]
+endif::VK_VALVE_partial_present[]
+
 ifdef::VK_KHR_display_swapchain[]
 include::{chapters}/VK_KHR_display_swapchain/display_swapchain_present.txt[]
 endif::VK_KHR_display_swapchain[]

--- a/chapters/VK_VALVE_partial_present/wsi.txt
+++ b/chapters/VK_VALVE_partial_present/wsi.txt
@@ -1,0 +1,88 @@
+// Copyright (c) 2014-2020 Khronos Group.
+//
+// SPDX-License-Identifier: CC-BY-4.0
+
+[open,refpage='VkPresentRegions2VALVE',desc='Structure of rectangular regions to update and hint of rectangular regions changed by vkQueuePresentKHR',type='structs']
+--
+
+When the `VK_VALVE_partial_present` extension is enabled, additional
+fields can: be specified that allow an application to specify that only
+certain rectangular regions of the presentable images of a swapchain are
+changed or to be updated on the surface, and an offset into the source
+swapchain image(s) for the update regions.
+
+Damage regions are an optimization hint that a presentation engine may:
+use to only update the region of a surface that is actually changing.
+The application still must: ensure that all pixels of a presented image
+contain the desired values, in case the presentation engine ignores this
+hint.
+
+An application can: provide this hint by adding a sname:VkPresentRegions2VALVE
+structure to the pname:pNext chain of the sname:VkPresentInfoKHR structure and
+filling in pname:pDamageRegions.
+
+Update regions the only regions on the surface that will be updated that a
+presentation engine must: use to only update a specific region of a surface.
+
+An application can: specify update regions and a source offset into the
+swapchain image(s) by adding a sname:VkPresentRegions2VALVE
+structure to the pname:pNext chain of the sname:VkPresentInfoKHR structure and
+filling in pname:pUpdateRegions.
+
+The distinction between damage regions and update regions is that damage regions
+specify the changed regions of an image as an optimization and may be ignored --
+where as update regions specify the only region that must be changed on the surface.
+
+The sname:VkPresentRegions2VALVE structure is defined as:
+
+include::{generated}/api/structs/VkPresentRegions2VALVE.txt[]
+
+  * pname:sType is the type of this structure.
+  * pname:pNext is `NULL` or a pointer to a structure extending this
+    structure.
+  * pname:swapchainCount is the number of swapchains being presented to by
+    this command.
+  * pname:pDamageRegions is `NULL` or a pointer to an array of
+    sname:VkPresentRegionKHR elements with pname:swapchainCount entries.
+    If not `NULL`, each element of pname:pDamageRegions contains the region that
+    has changed since the last present to the swapchain in the corresponding
+    entry in the sname:VkPresentInfoKHR::pname:pSwapchains array.
+  * pname:pUpdateRegions is `NULL` or a pointer to an array of
+    sname:VkUpdateRegionVALVE elements with pname:swapchainCount entries.
+    If not `NULL`, each element of pname:pUpdateRegions contains the
+    region that will be updated on the destination surfaces,
+    and a source offset into the swapchain image(s).
+
+.Valid Usage
+****
+  * pname:swapchainCount must: be the same value as
+    sname:VkPresentInfoKHR::pname:swapchainCount, where
+    sname:VkPresentInfoKHR is included in the pname:pNext chain of this
+    sname:VkPresentRegions2VALVE structure
+****
+
+include::{generated}/validity/structs/VkPresentRegions2VALVE.txt[]
+--
+
+[open,refpage='VkUpdateRegionVALVE',desc='Structure containing rectangular region of the surface to update for vkQueuePresentKHR and source offset for a given swapchain VkImage',type='structs']
+--
+
+For a given image and swapchain, the offset into the image and
+the region to update on the surface is specified by the
+sname:VkUpdateRegionVALVE structure, which is defined as:
+
+include::{generated}/api/structs/VkUpdateRegionVALVE.txt[]
+
+  * pname:srcOffset is the offset in pixels into the given image for the
+    swapchain's surface to update from.
+  * pname:dstRectangleCount is the number of rectangles in pname:pDstRectangles,
+    or zero if the entire surface is to be updated.
+  * pname:pDstRectangles is either `NULL` or a pointer to an array of
+    sname:VkRectLayerKHR structures.
+    The sname:VkRectLayerKHR structure is the framebuffer coordinates, plus
+    layer, of the region to update on the swapchain's surface.
+    If non-`NULL`, each entry in pname:pDstRectangles is a rectangle of the
+    given swapchain's surface to be updated.
+
+include::{generated}/validity/structs/VkUpdateRegionVALVE.txt[]
+-- 

--- a/xml/vk.xml
+++ b/xml/vk.xml
@@ -4809,6 +4809,18 @@ typedef void <name>CAMetalLayer</name>;
             <member><type>VkDeviceSize</type>                       <name>robustStorageBufferAccessSizeAlignment</name></member>
             <member><type>VkDeviceSize</type>                       <name>robustUniformBufferAccessSizeAlignment</name></member>
         </type>
+        <type category="struct" name="VkUpdateRegionVALVE">
+            <member><type>VkOffset2D</type>                       <name>srcOffset</name><comment>The offset, in pixels, to the swapchain image(s) to be presented</comment></member>
+            <member optional="true"><type>uint32_t</type>         <name>dstRectangleCount</name><comment>Number of rectangles in pDstRectangles</comment></member>
+            <member optional="true" len="rectangleCount">const <type>VkRectLayerKHR</type>*   <name>pDstRectangles</name><comment>Array of rectangles to update on the destination surface</comment></member>
+        </type>
+        <type category="struct" name="VkPresentRegions2VALVE" structextends="VkPresentInfoKHR">
+            <member values="VK_STRUCTURE_TYPE_PRESENT_REGIONS2_VALVE"><type>VkStructureType</type> <name>sType</name></member>
+            <member>const <type>void</type>*                          <name>pNext</name></member>
+            <member><type>uint32_t</type>                             <name>swapchainCount</name><comment>Copy of VkPresentInfoKHR::swapchainCount</comment></member>
+            <member len="swapchainCount" optional="true">const <type>VkPresentRegionKHR</type>*   <name>pDamageRegions</name><comment>The regions that have, equivelant to VkPresentRegionsKHR::pRegions</comment></member>
+            <member len="swapchainCount" optional="true">const <type>VkUpdateRegionVALVE</type>*  <name>pUpdateRegions</name><comment>The only regions that must be updated, exclusively</comment></member>
+        </type>
     </types>
 
     <comment>Vulkan enumerant (token) definitions</comment>
@@ -13769,10 +13781,13 @@ typedef void <name>CAMetalLayer</name>;
                 <enum value="&quot;VK_EXT_extension_340&quot;"              name="VK_EXT_EXTENSION_340_EXTENSION_NAME"/>
             </require>
         </extension>
-        <extension name="VK_EXT_extension_341" number="341" author="EXT" contact="Joshua Ashton @Joshua-Ashton" supported="disabled">
+        <extension name="VK_VALVE_partial_present" number="341" type="device" requires="VK_KHR_incremental_present" author="VALVE" contact="Joshua Ashton @Joshua-Ashton" supported="vulkan">
             <require>
-                <enum value="0"                                             name="VK_EXT_EXTENSION_341_SPEC_VERSION"/>
-                <enum value="&quot;VK_EXT_extension_341&quot;"              name="VK_EXT_EXTENSION_341_EXTENSION_NAME"/>
+                <enum value="1"                                             name="VK_VALVE_PARTIAL_PRESENTATION_SPEC_VERSION"/>
+                <enum value="&quot;VK_VALVE_partial_present&quot;"     name="VK_VALVE_PARTIAL_PRESENTATION_EXTENSION_NAME"/>
+                <enum offset="0" extends="VkStructureType"                  name="VK_STRUCTURE_TYPE_PRESENT_REGIONS2_VALVE"/>
+                <type name="VkPresentRegions2VALVE"/>
+                <type name="VkUpdateRegionVALVE"/>
             </require>
         </extension>
         <extension name="VK_EXT_extension_342" number="342" author="EXT" contact="Ralph Potter gitlab:@r_potter" supported="disabled">


### PR DESCRIPTION
A point of interest:
 - Should we have something at swapchain creation time to explicitly disable flipping to support this?
  - If at presentation time we'd need to recreate the swapchain in order to do that, that might be a problem, so maybe we should make this explicit instead of just going for OUT_OF_DATE_KHR.